### PR TITLE
Fix compilation on Mac OS X 10.8 and eariler

### DIFF
--- a/lib/libre2/util/util.h
+++ b/lib/libre2/util/util.h
@@ -40,7 +40,7 @@ using std::sort;
 using std::swap;
 using std::make_pair;
 
-#if defined(__GNUC__) && !defined(USE_CXX0X) && !defined(__llvm__)
+#if defined(__GNUC__) && !defined(USE_CXX0X) && !defined(_LIBCPP_VERSION)
 
 #include <tr1/unordered_set>
 using std::tr1::unordered_set;


### PR DESCRIPTION
`__llvm__` is defined for both gcc 4.2 and fresh new clang 5.0, so it doesn't help there.

The problem is that there are two standard libraries: `libstdc++` and `libc++`. Starting from Mavericks, `libc++` is used by default and TR1 is not available anymore. `_LIBCPP_VERSION` is a correct way to check which library is used.
