### PR TITLE
do not explicitly use gcc for dependency analysis in build

### DIFF
--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -6,7 +6,7 @@ let dispatch = function
     rule "Generate src/options.ml"
       ~prod:"src/options.ml"
       ~deps:["src/options.mlp"; "src/enum_x_macro.h"]
-      (fun _ _ -> Cmd (S[A"gcc"; A"-E"; A"-P"; A"-x"; A"c";
+      (fun _ _ -> Cmd (S[A"cc"; A"-E"; A"-P"; A"-x"; A"c";
                          P"src/options.mlp"; A"-o"; P"src/options.ml"]));
 
     flag ["ocaml"; "link"; "library"; "native"] (S[A"-cclib"; A"-Llib";


### PR DESCRIPTION
FreeBSD's default compiler is clang, which will be picked up
correctly if `cc` is used instead