### PR TITLE
Build with -std=c++11

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 RE2_HOME=libre2
 LIBRE2=$(RE2_HOME)/obj/libre2.a
 
-CXXFLAGS += -I $(RE2_HOME)/re2
+CXXFLAGS += -I $(RE2_HOME)/re2 -std=c++11
 
 CXX_WARNINGS ?= -Wall -Wextra -Wunused -Werror \
 	-Wcast-align -Wpointer-arith -Wfloat-equal -Wlarger-than-512 -Wredundant-decls \
@@ -15,7 +15,7 @@ dllre2_stubs.so libre2_stubs.a: stubs.o $(LIBRE2)
 	cp $(LIBRE2) libre2_stubs.a && ar r libre2_stubs.a stubs.o
 
 stubs.o: stubs.cpp stubs.h util.h enum_x_macro.h
-	$(CXX) -O2 -DPIC -fPIC -g -pipe -DCAML_NAME_SPACE $(CXX_WARNINGS) -I. -I../../../include \
+	$(CXX) $(CXXFLAGS) -O2 -DPIC -fPIC -g -pipe -DCAML_NAME_SPACE $(CXX_WARNINGS) -I. -I../../../include \
 	-I$(RE2_HOME) -I$(ocaml-version-selected-include-path) -c stubs.cpp
 
 #stubs.o: %.o: %.cpp %.h


### PR DESCRIPTION
Required since google/re2@cd505f4597d4022902b25bd036de29478e22d481
(released in 20160301) which uses C++11 atomics.

Debian uses upstream RE2 directly, rather than the bundled version, so
we [hit this](https://bugs.debian.org/820937) before you did.
