### PR TITLE
Fix find_first segfault when given named subpattern is not in the regex

### DIFF
--- a/src/re2_internal.ml
+++ b/src/re2_internal.ml
@@ -85,10 +85,6 @@ let create ?options pat = Or_error.try_with (fun () -> create_exn ?options pat)
 
 let num_submatches t          = cre2__num_submatches t
 let pattern t                 = cre2__pattern t
-(*let submatch_index_exn t name =
-  let i = cre2__submatch_index t name in
-  if i < 0 then raise (Regex_no_such_named_subpattern (name, pattern t)) else i
-let submatch_index t name     = Or_error.try_with (fun () -> submatch_index_exn t name)*)
 
 let of_string pat = create_exn pat
 let to_string t   = cre2__pattern t
@@ -110,7 +106,9 @@ let index_of_id_exn t = function
   | `Index i ->
     let max = num_submatches t in
     if i <= max then i else raise (Regex_no_such_subpattern (i, max))
-  | `Name name -> cre2__submatch_index t name
+  | `Name name ->
+    let i = cre2__submatch_index t name in
+    if i < 0 then raise (Regex_no_such_named_subpattern (name, pattern t)) else i
 ;;
 
 module Match = struct


### PR DESCRIPTION
When I call find_first/find_first_exn like in the following example, re2 causes a segfault:

``` OCaml
let re = Re2.of_string "(?P<numbers>[0-9]+)" in
let text = "53153153" in
Re2.find_first_exn ~sub:(`Name "nonsense") re text
```

The reason is that mlre2__submatch_index returns -1 when there's no such subpattern with the given name. In turn, sub in the following line points to the memory which we might not own:

https://github.com/janestreet/re2/blob/90af8812e5e9f32ba78fc8e501b5a70fbd426303/src/stubs.cpp#L394
