### PR TITLE
Don't rely on re2 to expose map

### DIFF
--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -265,7 +265,7 @@ extern "C" {
   }
 
   CAMLprim value mlre2__submatch_index(value v_regex, value v_name) {
-    map<string, int>::const_iterator it =
+    std::map<string, int>::const_iterator it =
       Regex_val(v_regex)->NamedCapturingGroups().find(String_val(v_name));
     if (it == Regex_val(v_regex)->NamedCapturingGroups().end()) {
       return Val_int(-1);


### PR DESCRIPTION
It used to have "using std::map" in re2.h, until
google/re2@ee55a8f64d253bdf5bfa98e8d09901a5fb9ee13c