### PR TITLE
Adding bindings for RE2::Set

### DIFF
--- a/src/re2_internal_intf.ml
+++ b/src/re2_internal_intf.ml
@@ -260,4 +260,18 @@ module Exceptions : sig
   exception Regex_rewrite_template_invalid of string * string
 end
 
+module Dict : sig
+  (** Regular expression dictionary mapping patterns to a record type *)
+  type 'a redict
+             
+  (** Construct a dictionary from the given association list. Compile
+      the strings as regular expressions using the provided options. *)
+  val make : ?options:Options.t list -> (string * 'a) list -> 'a redict option
+
+  (** Retrieve all records associated with a pattern matching the
+      provided input string. Records are returned in an unspecified
+      order *)
+  val get_all : 'a redict -> string -> 'a list
+end
+
 end

--- a/src/re2_internal_intf.ml
+++ b/src/re2_internal_intf.ml
@@ -266,7 +266,8 @@ module Dict : sig
              
   (** Construct a dictionary from the given association list. Compile
       the strings as regular expressions using the provided options. *)
-  val make : ?options:Options.t list -> (string * 'a) list -> 'a redict option
+  val make : ?options:Options.t list -> (string * 'a) list -> 'a redict Or_error.t
+  val make_exn : ?options:Options.t list -> (string * 'a) list -> 'a redict
 
   (** Retrieve all records associated with a pattern matching the
       provided input string. Records are returned in an unspecified

--- a/src/stubs.cpp
+++ b/src/stubs.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include "re2/re2.h"
-// #define DEBUG
+#include "re2/set.h"
+//#define DEBUG
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -155,9 +156,25 @@ extern "C" {
 #endif
   };
 
+  void mlre2__custom_regex_set_finalize(value v_obj) {
+    delete RegexSet_val(v_obj);
+  }
+
+  struct custom_operations mlre2__custom_regex_set_ops = {
+    (char *)"com.janestreet.re2-ocaml.regex-set-v20Mar2014",
+    mlre2__custom_regex_set_finalize,
+    custom_compare_default,
+    custom_hash_default,
+    custom_serialize_default,
+    custom_deserialize_default,
+#ifdef custom_compare_ext_default
+    custom_compare_ext_default
+#endif
+  };
 
   CAMLprim void mlre2__init(void) {
     caml_register_custom_operations(&mlre2__custom_regex_ops);
+    caml_register_custom_operations(&mlre2__custom_regex_set_ops);
   }
 
   static int new_pos(const char *input, StringPiece &remaining, int startpos, StringPiece &match) {
@@ -438,4 +455,64 @@ extern "C" {
     StringPiece str(String_val(v_str), caml_string_length(v_str));
     CAMLreturn(caml_copy_string(RE2::QuoteMeta(str).c_str()));
   }
+
+
+  CAMLprim value mlre2__create_set(value v_options) {
+    value v_retval;
+    RE2::Options opt;
+    RE2::Set* set = NULL;
+
+    opt.Copy(RE2::Quiet);
+    while (v_options != Val_emptylist) {
+      int val = Int_val(Field(Field(v_options, 0), 0));
+      switch (Tag_val(Field(v_options, 0))) {
+#define X(_u,FIRST,REST,_uu) case FIRST##REST : opt.set_##FIRST##REST(val); break;
+#define X__ENCODING(_u,FIRST,REST,_uu,SUFFIX,_uuu,TRANSLATED)               \
+        case FIRST##REST##SUFFIX : opt.set_##FIRST##REST(val TRANSLATED); break;
+#define X__MAXMEM(_u,FIRST,REST,_uu) X(_u,FIRST,REST,_uu)
+#include "enum_x_macro.h"
+      default              : caml_invalid_argument("invalid option\n");
+      }
+      v_options = Field(v_options, 1);
+    }
+
+    set = new RE2::Set(opt, RE2::UNANCHORED);
+
+    v_retval = caml_alloc_custom(&mlre2__custom_regex_set_ops, sizeof(set),
+        1024*1024,      /* RE2 object uses ~1MB of memory outside the OCaml heap */
+        500*1024*1024);  /* I'm okay with 500MB of RAM being wasted */
+
+    RegexSet_val(v_retval) = set;
+
+    return v_retval;
+  }
+
+  CAMLprim value mlre2__set_add(value v_set, value v_pattern){
+      char *pattern_str = String_val(v_pattern);
+      RE2::Set* set = RegexSet_val(v_set);
+      string errstr;
+      int idx = set->Add(pattern_str, &errstr);
+      if(idx < 0){
+	  caml_failwith(errstr.c_str());
+      }
+      return Val_int(idx);
+  }
+
+  CAMLprim value mlre2__set_compile(value v_set){
+      RE2::Set *set = RegexSet_val(v_set);
+      return set->Compile() ? Val_true : Val_false;
+  }
+
+  CAMLprim value mlre2__set_match(value v_set, value v_str){
+    char *str = String_val(v_str);
+    RE2::Set *set = RegexSet_val(v_set);
+    std::vector<int> matchV;
+    bool matches = set->Match(str, &matchV);
+    value res = caml_alloc_tuple(matchV.size());
+    for(int i = 0; i < matchV.size(); ++i){
+      Store_field(res, i, Val_int(matchV[i]));
+    }
+    return res;
+  }
+
 } /* extern "C" */

--- a/src/stubs.h
+++ b/src/stubs.h
@@ -82,6 +82,12 @@ extern "C" {
 
   extern value mlre2__escape(value _str);
 
+
+  extern value mlre2__create_set(value v_options);
+  extern value mlre2__set_add(value v_set, value v_pattern);
+  extern value mlre2__set_compile(value v_set);
+  extern value mlre2__set_match(value v_set, value v_str);
+
   /** a thin wrapper around RE2::QuoteMeta */
 } /* extern "C" */
 

--- a/src/util.h
+++ b/src/util.h
@@ -6,6 +6,7 @@
 #define Val_none (Val_int(0))
 
 #define Regex_val(v) (*(RE2 **) Data_custom_val(v))
+#define RegexSet_val(v) (*(RE2::Set **) Data_custom_val(v))
 
 #define PAIR(v_dst, v_a, v_b) do {                   \
     v_dst = caml_alloc_small(2, 0);                  \


### PR DESCRIPTION
This patch exposes the RE2::Set interface as a dictionary like object that allows the user to associate records with regular expressions, and, given an input string, to efficiently retrieve all records associated with matching patterns.