### PR TITLE
build: fix g++ hard dependency on FreeBSD [regression]

### DIFF
--- a/src/re2_c/jbuild
+++ b/src/re2_c/jbuild
@@ -22,8 +22,13 @@
   (deps ((files_recursively_in libre2)))
   (action (bash "
 ARFLAGS=rsc
-CXX=g++
 CXXFLAGS=\"-Wall -O3 -g -pthread\"
+if [ FreeBSD = `uname -s` ]; then
+       CXX=clang++
+       CXXFLAGS=\"$CXXFLAGS -I /usr/local/lib/re2\"
+else
+       CXX=g++
+fi
 if ! ${ARCH_SIXTYFOUR}; then
   CXX=\"$CXX -m32\"
 fi


### PR DESCRIPTION
> FreeBSD wintermute.skunkwerks.at 12.0-CURRENT FreeBSD 12.0-CURRENT  r335190+901e67d37d11(master)  amd64
> opam switch: 4.06.1  C 4.06.1  Official 4.06.1 release

switching to jbuild has re-introduced the hard g++ dependency - see https://github.com/janestreet/re2/issues/7 for history.

This PR has 2 issues - 

- [x] I've not figured out the jbuilder bash escaping rules that would allow `ifeq ($(shell uname),FreeBSD) ...` to work as it did in previous issue #7 

      /usr/local/bin/bash: -c: line 2: syntax error near unexpected token `$(shell uname),FreeBSD'

- [ ] there is still an ocaml failure in `src/regex.ml`:

I will fix the former but need a hand on the latter.

```
dch@wintermute /r/re2> cat /home/dch/.opam/4.06.1/build/re2.v0.11.0/re2-38132-ffb3fd.err
      ocamlc src/.re2.objs/re2__Regex.{cmo,cmt}
File "src/regex.ml", line 142, characters 25-46:
Warning 52: Code should not depend on the actual values of
this constructor's arguments. They are only for information
and may change in future versions. (See manual section 8.5)
    ocamlopt src/.re2.objs/re2__Regex.{cmx,o}
File "src/regex.ml", line 142, characters 25-46:
Warning 52: Code should not depend on the actual values of
this constructor's arguments. They are only for information
and may change in future versions. (See manual section 8.5)
      ocamlc src/.re2.objs/re2__Parser_intf.{cmi,cmo,cmt} (exit 2)
(cd _build/default && /home/dch/.opam/4.06.1/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.re2.objs -I /home/dch/.opam/4.06.1/lib/base -I /home/dch/.opam/4.06.1/lib/base/caml -I /home/dch/.opam/4.06.1/lib/base/md5 -I /home/dch/.opam/4.06.1/lib/base/shadow_stdlib -I /home/dch/.opam/4.06.1/lib/bin_prot -I /home/dch/.opam/4.06.1/lib/bin_prot/shape -I /home/dch/.opam/4.06.1/lib/core_kernel -I /home/dch/.opam/4.06.1/lib/core_kernel/base_for_tests -I /home/dch/.opam/4.06.1/lib/fieldslib -I /home/dch/.opam/4.06.1/lib/jane-street-headers -I /home/dch/.opam/4.06.1/lib/parsexp -I /home/dch/.opam/4.06.1/lib/ppx_assert/runtime-lib -I /home/dch/.opam/4.06.1/lib/ppx_bench/runtime-lib -I /home/dch/.opam/4.06.1/lib/ppx_compare/runtime-lib -I /home/dch/.opam/4.06.1/lib/ppx_expect/collector -I /home/dch/.opam/4.06.1/lib/ppx_expect/common -I /home/dch/.opam/4.06.1/lib/ppx_expect/config -I /home/dch/.opam/4.06.1/lib/ppx_hash/runtime-lib -I /home/dch/.opam/4.06.1/lib/ppx_inline_test/config -I /home/dch/.opam/4.06.1/lib/ppx_inline_test/runtime-lib -I /home/dch/.opam/4.06.1/lib/ppx_sexp_conv/runtime-lib -I /home/dch/.opam/4.06.1/lib/sexplib -I /home/dch/.opam/4.06.1/lib/sexplib0 -I /home/dch/.opam/4.06.1/lib/splittable_random -I /home/dch/.opam/4.06.1/lib/stdio -I /home/dch/.opam/4.06.1/lib/typerep -I /home/dch/.opam/4.06.1/lib/variantslib -I src/re2_c/.re2_c.objs -no-alias-deps -open Re2__ -o src/.re2.objs/re2__Parser_intf.cmo -c -impl src/parser_intf.pp.ml)
File "src/parser_intf.ml", line 142, characters 10-32:
Error: Unbound module type Applicative.Let_syntax
```