### PR TITLE
Support building under clang

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -4,7 +4,7 @@
   (libraries (core_kernel re2_c))
   (c_library_flags (:standard -lstdc++ -lpthread))
   (cxx_names (stubs))
-  (cxx_flags ((:standard \ -pedantic) (-I re2_c/libre2)))
+  (cxx_flags ((:standard -x c++ \ -pedantic) (-I re2_c/libre2)))
   (preprocess (pps (ppx_jane -check-doc-comments ppxlib.runner)))
   ))
 


### PR DESCRIPTION
clang(1) does not do language detection like gcc(1).  Using "-x c++" to
force the language mode works with both of these frontends.

Fixes: https://github.com/janestreet/re2/issues/21
